### PR TITLE
chore: .gitignoreを整備し.envをトラッキング対象から除外

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-TZ=JST-9
-SERVER_ADDRESS=google-home-voicetext-server
-SERVER_PORT=8080
-DEVICE_ADDRESS=192.168.20.200
-FIREBASE_CREDENTIAL=/tmp/cred/serviceAccountKey.json

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+TZ=JST-9
+SERVER_ADDRESS=your-server-address
+SERVER_PORT=8080
+DEVICE_ADDRESS=your-device-ip-address
+FIREBASE_CREDENTIAL=/path/to/serviceAccountKey.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,33 @@
+# 環境変数・シークレット
+.env
+.env.local
+.env.*.local
 serviceAccountKey.json
+credentials.json
+*.pem
+*.key
+
+# Node.js
+node_modules/
+npm-debug.log*
+npm-error.log*
+yarn-error.log*
+lerna-debug.log*
+
+# ログ
+logs/
+*.log
+
+# OS
+.DS_Store
+Thumbs.db
+
+# エディタ
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ツール
+.gstack/


### PR DESCRIPTION
## 変更の概要

`.env` ファイルがリポジトリにコミットされていた問題を修正し、`.gitignore` をこのプロジェクトに適した内容へ拡充します。

## 変更の理由/背景

- `.env` にはサーバーアドレスやデバイスIPなどの環境固有の設定が含まれており、Git で管理すべきではない
- 既存の `.gitignore` は `serviceAccountKey.json` のみで、他の機密ファイルや不要ファイルが対象外だった

## 主な変更点

- **`.env` をトラッキング対象から除外** (`git rm --cached`)
- **`.env.example` を追加** — 値をプレースホルダーに置き換えた設定テンプレート
- **`.gitignore` を拡充**:
  - 環境変数・シークレット: `.env`, `.env.local`, `serviceAccountKey.json`, `credentials.json`, `*.pem`, `*.key`
  - Node.js: `node_modules/`, `npm-debug.log*` など
  - ログ: `logs/`, `*.log`
  - OS: `.DS_Store`, `Thumbs.db`
  - エディタ: `.vscode/`, `.idea/`, `*.swp` など
  - ツール: `.gstack/`

## テスト方法

```bash
# .env が追跡対象外になっていることを確認
git ls-files | grep env
# → .env.example のみ表示されること

# .env ファイルがローカルに残っていることを確認
ls -la .env
```

## 関連Issue

なし