### PR TITLE
chore: DependabotのGitHub Actions設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Dependabot の依存関係自動更新設定を追加。

**Infrastructure:**
- `.github/dependabot.yml` を新規作成 — npm と docker の両エコシステムを週次スキャン、cooldown 7日
- Docker エントリに `ignore` ルールを追加 — Node.js のメジャーバージョンバンプ (16→18+) を自動無視 (CIなし環境での安全策)

## Test Coverage

No new application code paths added (config-only change) — coverage audit skipped.
Test bootstrap declined — no test framework configured.

## Pre-Landing Review

No issues found. (config-only YAML, no application code paths, confidence: 10/10)

Small diff (15 lines) — specialists skipped.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

- [x] `.github/dependabot.yml` 新規作成
- [x] npm エコシステム設定 (weekly, cooldown 7日)
- [x] docker エコシステム設定 (weekly, cooldown 7日)
- [x] 両エントリに `cooldown.default-days: 7` 設定済み

4/4 items DONE.

## Verification Results

No dev server detected — config-only change, no runtime verification needed.

## Known Limitations (deferred from autoplan review)

- Node.js 16 (EOL) → LTS アップグレードは別 PR で対応予定
- `request` / `request-promise` 廃止パッケージの代替は別 PR
- `package-lock.json` 未生成 → Dependabot npm PRの推移的依存解決精度に影響
- CI (GitHub Actions test workflow) 未設定 → Dependabot PR の自動検証なし

## Test plan

- [ ] GitHub の Insights → Dependency graph → Dependabot タブで設定認識を確認
- [ ] 最初の週次スキャン後 (最大7日) に npm/docker Dependabot PR が生成されることを確認
- [ ] `cooldown.default-days: 7` で YAML parse エラーが出ないことを Dependabot タブで確認
- [ ] `node:16.x → 18` のメジャーバンプ PR が作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)