### PR TITLE
fix: firebase-admin v14 モジュラー API に移行

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,14 +6,13 @@ validateEnv();
 
 const endpointUrl = buildEndpointUrl();
 
-const admin = require('firebase-admin');
+const { initializeApp, cert } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
 const serviceAccount = require(process.env['FIREBASE_CREDENTIAL']);
-admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount)
-});
+initializeApp({ credential: cert(serviceAccount) });
 
 const docpath = process.env['FIREBASE_DOCPATH'] || '/googlehome/chant';
-const firestore = admin.firestore();
+const firestore = getFirestore();
 const document = firestore.doc(docpath);
 document.onSnapshot(
     (docSnapshot) => handleSnapshot(docSnapshot, endpointUrl, document),


### PR DESCRIPTION
## 概要

firebase-admin v14 で削除された名前空間 API (`admin.credential`、`admin.firestore()`) をモジュラー API に移行する。

## 背景

Dependabot が firebase-admin を v14.0.0 に更新した結果、起動時に以下のエラーが発生していた:

```
TypeError: Cannot read properties of undefined (reading 'cert')
    at /app/main.js  (credential: admin.credential.cert(serviceAccount))
```

v14 では `require('firebase-admin')` の戻り値に `credential` プロパティが存在しない。

## 変更内容

`main.js` の firebase-admin 初期化部分（4行）を変更:

| 変更前 | 変更後 |
|--------|--------|
| `require('firebase-admin')` | `require('firebase-admin/app')` + `require('firebase-admin/firestore')` |
| `admin.credential.cert()` | `cert()` (直接インポート) |
| `admin.initializeApp()` | `initializeApp()` (直接インポート) |
| `admin.firestore()` | `getFirestore()` (直接インポート) |

`lib/handler.js` 側（`firestore.doc()`、`onSnapshot()`、`document.update()` 等）は変更不要。

## テスト

- `npm test`: 全 13 件パス (Vitest)
- CI: `.github/workflows/test.yml` で自動実行