### PR TITLE
fix: DEVICE_ADDRESS の URL パス補完と k8s マウントパス修正

### DIFF
--- a/k8s-google-home-voicetext-firebase.yml
+++ b/k8s-google-home-voicetext-firebase.yml
@@ -24,7 +24,7 @@ spec:
             name: google-home-voicetext-firebase
         volumeMounts:
         - name: firebase-credential
-          mountPath: /tmp/cred
+          mountPath: /app/cred
           readOnly: true
       volumes:
       - name: firebase-credential
@@ -43,4 +43,4 @@ data:
   SERVER_ADDRESS: 'google-home-voicetext-server'
   SERVER_PORT: '80'
   DEVICE_ADDRESS: ''
-  FIREBASE_CREDENTIAL: '/tmp/cred/serviceAccountKey.json'
+  FIREBASE_CREDENTIAL: '/app/cred/serviceAccountKey.json'

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -15,7 +15,9 @@ function validateEnv() {
 
 function buildEndpointUrl() {
     const port = process.env['SERVER_PORT'] || 8080;
-    return `http://${process.env['SERVER_ADDRESS']}:${port}${process.env['DEVICE_ADDRESS']}`;
+    const device = process.env['DEVICE_ADDRESS'];
+    const devicePath = device.startsWith('/') ? device : `/${device}`;
+    return `http://${process.env['SERVER_ADDRESS']}:${port}${devicePath}`;
 }
 
 async function handleSnapshot(docSnapshot, endpointUrl, document) {

--- a/tests/handler.test.js
+++ b/tests/handler.test.js
@@ -51,6 +51,13 @@ describe('buildEndpointUrl', () => {
         vi.stubEnv('DEVICE_ADDRESS', '/api/tts');
         expect(buildEndpointUrl()).toBe('http://192.168.1.10:8080/api/tts');
     });
+
+    test('DEVICE_ADDRESS がスラッシュなし: 先頭に / を補完する', () => {
+        vi.stubEnv('SERVER_ADDRESS', 'google-home-voicetext-server');
+        vi.stubEnv('DEVICE_ADDRESS', 'device.local');
+        vi.stubEnv('SERVER_PORT', '12080');
+        expect(buildEndpointUrl()).toBe('http://google-home-voicetext-server:12080/device.local');
+    });
 });
 
 describe('handleSnapshot', () => {


### PR DESCRIPTION
## Summary

- `DEVICE_ADDRESS` に先頭スラッシュがない場合（IP アドレスや mDNS ホスト名）に `buildEndpointUrl()` が不正な URL を生成する問題を修正
- k8s ConfigMap / volumeMount のパスを `/tmp/cred` から `/app/cred` に修正

## Commits

1. **fix: k8s マウントパスを /tmp/cred から /app/cred に修正**
2. **fix: DEVICE_ADDRESS にスラッシュがない場合に自動補完する**

## Test plan

- [ ] `npm test` が全 14 テストパスすることを確認
- [ ] `DEVICE_ADDRESS` にスラッシュなしの値を設定した場合、URL の先頭に `/` が補完されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)